### PR TITLE
Rename deviceName config key to device_name

### DIFF
--- a/app/src/main/java/ohi/andre/consolelauncher/UIManager.java
+++ b/app/src/main/java/ohi/andre/consolelauncher/UIManager.java
@@ -1157,7 +1157,7 @@ public class UIManager implements OnTouchListener {
             String deviceFormat = XMLPrefsManager.get(Behavior.device_format);
 
             String username = XMLPrefsManager.get(Ui.username);
-            String deviceName = XMLPrefsManager.get(Ui.deviceName);
+            String deviceName = XMLPrefsManager.get(Ui.device_name);
             if (deviceName == null || deviceName.length() == 0) {
                 deviceName = Build.DEVICE;
             }

--- a/app/src/main/java/ohi/andre/consolelauncher/managers/xml/XMLPrefsManager.java
+++ b/app/src/main/java/ohi/andre/consolelauncher/managers/xml/XMLPrefsManager.java
@@ -814,7 +814,7 @@ public class XMLPrefsManager {
 //            new SimpleMutableEntry("inputFieldBottom", Ui.input_bottom),
 //            new SimpleMutableEntry("username", Ui.username),
 //            new SimpleMutableEntry("showSubmit", Ui.show_enter_button),
-//            new SimpleMutableEntry("deviceName", Ui.deviceName),
+//            new SimpleMutableEntry("deviceName", Ui.device_name),
 //            new SimpleMutableEntry("showRam", Ui.show_ram),
 //            new SimpleMutableEntry("showDevice", Ui.show_device_name),
 //            new SimpleMutableEntry("showToolbar", Toolbar.show_toolbar),

--- a/app/src/main/java/ohi/andre/consolelauncher/managers/xml/options/Ui.java
+++ b/app/src/main/java/ohi/andre/consolelauncher/managers/xml/options/Ui.java
@@ -332,7 +332,7 @@ public enum Ui implements XMLPrefsSave {
             return "Your username";
         }
     },
-    deviceName {
+    device_name {
         @Override
         public String defaultValue() {
             return Build.DEVICE;

--- a/app/src/main/java/ohi/andre/consolelauncher/tuils/Tuils.java
+++ b/app/src/main/java/ohi/andre/consolelauncher/tuils/Tuils.java
@@ -1004,7 +1004,7 @@ public class Tuils {
         String format = XMLPrefsManager.get(Behavior.session_info_format);
         if(format.length() == 0) return null;
 
-        String deviceName = XMLPrefsManager.get(Ui.deviceName);
+        String deviceName = XMLPrefsManager.get(Ui.device_name);
         if(deviceName == null || deviceName.length() == 0) {
             deviceName = Build.DEVICE;
         }


### PR DESCRIPTION
To be coherent with the other configuration keys being snake_case, I renamed `deviceName` to `device_name`. It should break the actual configured value, but setting it again should be fine.